### PR TITLE
KM-11175: Bump version to 1.5.4

### DIFF
--- a/account/build.gradle.kts
+++ b/account/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     group = "com.kape.android"
-    version = "1.5.3"
+    version = "1.5.4"
 
     jvmToolchain(17)
 


### PR DESCRIPTION
## Summary

As per title, it bumps the version to `1.5.4`.

## Sanity Tests

N/A